### PR TITLE
fix test, tweak workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,6 @@ jobs:
         path: ~/.nimble
         key: ${{ runner.os }}-nimble-stable
 
-    - uses: jiro4989/setup-nim-action@v1.0.2
+    - uses: jiro4989/setup-nim-action@v1
 
     - run: nimble test -y

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -41,7 +41,10 @@ block:
   a.add false
   a.add true
   a.add false
-  assert a.hash() == -4445816759453838206
+  var b = newBitArray()
+  b.add false
+  b.add true
+  assert a.hash() != b.hash()
 
 block:
   var a = newBitArray(4)


### PR DESCRIPTION
- hash result value doesnt appear to be stable across nim versions
- no need to be specific in workflow version beyond v1, as shown in the example https://github.com/jiro4989/setup-nim-action#basic-usage